### PR TITLE
Improved syntax highlighting and comment handling

### DIFF
--- a/gleam-mode.el
+++ b/gleam-mode.el
@@ -23,6 +23,9 @@
 ;;;###autoload
 (define-derived-mode gleam-mode c-mode "gleam mode"
   "Major mode for editing gleam"
+  ;; use // for commenting lines
+  (setq-local comment-start "// ")
+  (setq-local comment-end "")
 
   ;; code for syntax highlighting
   (setq font-lock-defaults '((gleam-font-lock-keywords))))

--- a/gleam-mode.el
+++ b/gleam-mode.el
@@ -3,7 +3,7 @@
 (setq gleam-font-lock-keywords
       (let* (
             ;; define several category of keywords
-            (x-keywords '("case" "external" "fn" "import" "let" "pub" "type"
+            (x-keywords '("case" "const" "external" "fn" "import" "let" "pub" "type"
                           "assert" "try" "tuple" "opaque"))
             (x-booleans '("True" "False"))
 

--- a/gleam-mode.el
+++ b/gleam-mode.el
@@ -14,6 +14,8 @@
         `(
           (,x-keywords-regexp . font-lock-keyword-face)
           (,x-booleans-regexp . font-lock-constant-face)
+          ("fn \\([_[:alpha:]]+\\)(" 1 font-lock-function-name-face)
+          ("[[:upper:]][[:alpha:]]*" . font-lock-type-face)
           ;; note: order above matters, because once colored, that part won't change.
           ;; in general, put longer words first
           )))

--- a/gleam-mode.el
+++ b/gleam-mode.el
@@ -8,7 +8,7 @@
             (x-booleans '("True" "False"))
 
             ;; generate regex string for each category of keywords
-            (x-keywords-regexp (regexp-opt x-keywords 'words))
+            (x-keywords-regexp (regexp-opt x-keywords 'symbols))
             (x-booleans-regexp (regexp-opt x-booleans 'words)))
 
         `(


### PR DESCRIPTION
There are some minor quality of life improvements I've been running locally for a week or so without issue.

- Added the `const` keyword
- Syntax highlighting for functions and types
- Emacs shortcuts for adding comments now use `//` instead of `/* ... */`
- Fixed an issue where keywords in string like `foo_tuple` would be highlighted

The syntax regexes are pretty simplistic, but as far as I can tell, they aren't any valid language constructs where they misbehave. 

![screenshot](https://user-images.githubusercontent.com/604797/103461400-46dfd880-4cec-11eb-9131-8bfc1b1145a9.png)
