### PR TITLE
Update keywords list

### DIFF
--- a/gleam-mode.el
+++ b/gleam-mode.el
@@ -3,8 +3,8 @@
 (setq gleam-font-lock-keywords
       (let* (
             ;; define several category of keywords
-            (x-keywords '("case" "const" "external" "fn" "import" "let" "pub" "type"
-                          "assert" "try" "tuple" "opaque"))
+            (x-keywords '("as" "assert" "case" "const" "external" "fn" "if"
+                          "import" "let" "opaque" "pub" "todo" "try" "type"))
             (x-booleans '("True" "False"))
 
             ;; generate regex string for each category of keywords


### PR DESCRIPTION
I noticed that "as" was missing from the list, and decided to update the whole list while I was there. This change makes the `x-keywords` list match the [keyword token list in the Gleam parser](https://github.com/gleam-lang/gleam/blob/main/compiler-core/src/parse/token.rs#L59-L73).

I also alphabetized the list such that it matches the parser.

Changes:
- Add "as"
- Add "if"
- Add "todo"
- Remove "tuple"
- Alphabetization