### PR TITLE
Fix uncomment-region

### DIFF
--- a/gleam-mode.el
+++ b/gleam-mode.el
@@ -123,7 +123,7 @@ Key bindings:
   (setq-local comment-start "// ")
   (setq-local comment-end "")
   (setq-local comment-start-skip "//+ *")
-  (setq-local comment-use-syntax t)
+  (setq-local comment-use-syntax nil)
   (setq-local comment-auto-fill-only-comments t)
 
   ;; Register compilation error format


### PR DESCRIPTION
Fixes #25  by setting `comment-use-syntax` to `nil`

