### PR TITLE
Document associating gleam-ts-mode with .gleam file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Then you'll need to load this from your init script (`~/.emacs` or `~/.config/em
 
 ```elisp
 (use-package gleam-ts-mode
-  :load-path "~/path/to/gleam-mode")
+  :load-path "~/path/to/gleam-mode"
+  :mode (rx ".gleam" eos))
 ```
 
 Replace `~/path/to/gleam-mode` with the path where you cloned gleam-mode.


### PR DESCRIPTION
Yo, thanks for putting this together.

When `use-package`-ing a local clone of the repo as shown in the README, opening a `.gleam` file would just display the file as plain text.

(Presumably once `gleam-mode` (non-Treesitter) is officially retired then `gleam-ts-mode` will be able to takeover the file extension and automatically claim it for itself?)


