### PR TITLE
Use more appropriate font face for identifier of function being called

### DIFF
--- a/gleam-ts-mode.el
+++ b/gleam-ts-mode.el
@@ -93,7 +93,7 @@
      (external_function
       name: (identifier) @font-lock-function-name-face)
      (function_call
-      function: (identifier) @font-lock-function-name-face))
+      function: (identifier) @font-lock-function-call-face))
 
    :feature 'variable-name
    :language 'gleam


### PR DESCRIPTION
I think the two faces `font-lock-function-name-face` and `font-lock-function-call-face` are for a function's "declaration site" and "use  sites" respectively.

If the user's theme doesn't specify a colour for the latter then it inherits from the former anyway, so there won't be a visual change in that case.

