### PR TITLE
add echo keyword

### DIFF
--- a/gleam-ts-mode.el
+++ b/gleam-ts-mode.el
@@ -147,6 +147,7 @@
       "todo"
       "type"
       "use"
+      "echo"
       ] @font-lock-keyword-face)
 
    :feature 'operator


### PR DESCRIPTION
Adds `echo` to keywords.

Added to gleam v1.9.0