### PR TITLE
autoload gleam-ts-install-grammar and gleam-ts-format

### DIFF
--- a/gleam-ts-mode.el
+++ b/gleam-ts-mode.el
@@ -335,6 +335,7 @@ otherwise, it aligns with the initial expression."
 
 ;;; Public functions
 
+;;;###autoload
 (defun gleam-ts-install-grammar ()
   "Install the Gleam tree-sitter grammar."
   (interactive)
@@ -347,6 +348,7 @@ otherwise, it aligns with the initial expression."
         (treesit-install-language-grammar 'gleam))
     (display-warning 'treesit "Emacs' treesit package does not appear to be available")))
 
+;;;###autoload
 (defun gleam-ts-format ()
   "Format the current buffer using the `gleam format' command."
   (interactive)


### PR DESCRIPTION
this makes these functions available after `package-install-file` without also needing to `require` the package