### PR TITLE
Add `:ensure t` to suggested `use-package` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This project is hosted on [MELPA], and this is the recommended way to install th
 Add the following to your Emacs init file:
 ```elisp
 (use-package gleam-ts-mode
+  :ensure t
   :mode (rx ".gleam" eos))
 ```
 


### PR DESCRIPTION
Since the default for `use-package-always-ensure` is `nil`, adding `:ensure t` makes sure that anyone who copies this snippet into their own config will have the package automatically installed. For users with `use-package-always-ensure` set to `t`, this change won't affect the behaviour, and they can always remove it if they'd like.